### PR TITLE
Fix broken url to better Bloom filter paper

### DIFF
--- a/deps/wiredtiger-2.1.2/src/include/bloom.h
+++ b/deps/wiredtiger-2.1.2/src/include/bloom.h
@@ -6,7 +6,7 @@
  */
 /*
  * REFERENCES:
- *      http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
+ *      https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf
  *      http://code.google.com/p/cityhash-c/
  */
 


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author